### PR TITLE
Fixes memory leak. Works around compiler optimization bug...

### DIFF
--- a/KeychainObjCWrapper.h
+++ b/KeychainObjCWrapper.h
@@ -1,0 +1,15 @@
+//
+//  KeychainObjCWrapper.h
+//  PAKeychainService
+//
+//  Created by Andrew Ebling on 02/01/2015.
+//  Copyright (c) 2015 Tenero Mobile Limited. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface KeychainObjCWrapper : NSObject
+
++ (NSString *)keychainValueForDictionary: (NSDictionary *)inQueryDict;
+
+@end

--- a/KeychainObjCWrapper.m
+++ b/KeychainObjCWrapper.m
@@ -1,0 +1,38 @@
+//
+//  KeychainObjCWrapper.m
+//  PAKeychainService
+//
+//  Created by Andrew Ebling on 02/01/2015.
+//  Copyright (c) 2015 Tenero Mobile Limited. All rights reserved.
+//
+
+#import "KeychainObjcWrapper.h"
+#import <Security/Security.h>
+
+@implementation KeychainObjCWrapper
+
++ (NSString *)keychainValueForDictionary: (NSDictionary *)inQueryDict {
+    
+    CFTypeRef cfKeychainResult = NULL;
+    OSStatus err = SecItemCopyMatching((__bridge CFDictionaryRef)inQueryDict, &cfKeychainResult);
+    
+    if(err == noErr) {
+        
+        // transfer ownership so ARC will take care of releasing underlying CF object
+        id resultObj = (__bridge_transfer id)cfKeychainResult;
+        
+        // programmer error if query to constructed to return something else
+        NSAssert([resultObj isKindOfClass: [NSData class]],
+                 @"Expected an instance of NSData as keychain result");
+        
+        if([resultObj isKindOfClass: [NSData class]]) {
+            return [[NSString alloc] initWithData: resultObj encoding: NSUTF8StringEncoding];
+        } else {
+            return nil;
+        }
+    } else {
+        return nil;
+    }
+}
+
+@end

--- a/PAKeychainService-Bridging-Header.h
+++ b/PAKeychainService-Bridging-Header.h
@@ -1,0 +1,5 @@
+//
+//  Use this file to import your target's public headers that you would like to expose to Swift.
+//
+
+#import "KeychainObjCWrapper.h"

--- a/PAKeychainService.swift
+++ b/PAKeychainService.swift
@@ -36,7 +36,7 @@ class PAKeychainService: NSObject {
         let dataFromString = value.dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: false)!
         
         let keychainQuery = NSMutableDictionary(objects: [kSecClassGenericPasswordValue, serviceString(),      key,                  dataFromString],
-                                                forKeys: [kSecClassValue,                kSecAttrServiceValue, kSecAttrAccountValue, kSecValueDataValue])
+            forKeys: [kSecClassValue,                kSecAttrServiceValue, kSecAttrAccountValue, kSecValueDataValue])
         
         SecItemDelete(keychainQuery as CFDictionaryRef)
         SecItemAdd(keychainQuery as CFDictionaryRef, nil)
@@ -46,19 +46,10 @@ class PAKeychainService: NSObject {
     func getContentsOfKey(key: String) -> String? {
         
         let keychainQuery = NSMutableDictionary(objects: [kSecClassGenericPasswordValue, serviceString(),      key,                  kCFBooleanTrue,      kSecMatchLimitOneValue],
-                                                forKeys: [kSecClassValue,                kSecAttrServiceValue, kSecAttrAccountValue, kSecReturnDataValue, kSecMatchLimitValue])
+            forKeys: [kSecClassValue,                kSecAttrServiceValue, kSecAttrAccountValue, kSecReturnDataValue, kSecMatchLimitValue])
         
-        var dataTypeRef :Unmanaged<AnyObject>?
-        let status = SecItemCopyMatching(keychainQuery, &dataTypeRef)
-        let opaque = dataTypeRef?.toOpaque()
-        var contentsOfKeychain: String?
-        if let op = opaque? {
-            let retrievedData: NSData = Unmanaged<NSData>.fromOpaque(op).takeUnretainedValue()
-            contentsOfKeychain = NSString(data: retrievedData, encoding: NSUTF8StringEncoding)
-        } else {
-            devPrintln("Nothing was retrieved from the keychain. Status code \(status)")
-        }
-        return  contentsOfKeychain
+        // we do the read in Objective-C to work around a Swift compiler optimization bug (as of Xcode 6.2 (6C101) which resulted in no data being returned
+        return  KeychainObjCWrapper.keychainValueForDictionary(keychainQuery)
     }
     
     private func serviceString() -> String {


### PR DESCRIPTION
.... (as of Xcode 6.2 beta 3 (6C101)), which resulted in no data being returned for optimized builds (e.g. Release builds by default); this is achieved by doing the keychain read from Objective-C, which although not pretty is less nuclear than disabling compiler optimization for the whole Swift project.